### PR TITLE
Added missing port and ssl option.

### DIFF
--- a/src/Spryker/Service/FlysystemFtpFileSystem/Model/Builder/Adapter/FtpAdapterBuilder.php
+++ b/src/Spryker/Service/FlysystemFtpFileSystem/Model/Builder/Adapter/FtpAdapterBuilder.php
@@ -58,6 +58,8 @@ class FtpAdapterBuilder implements AdapterBuilderInterface
             '',
             $this->adapterConfig->getUsernameOrFail(),
             $this->adapterConfig->getPasswordOrFail(),
+            $this->adapterConfig->getPort(),
+            $this->adapterConfig->getSsl(),
         );
 
         return $this;


### PR DESCRIPTION
Added missing port and SSL option to FtpAdapterBuilder. 
Spryker officially supports FTPS, but it doesn't actually work because of this bug. 
